### PR TITLE
Fix show suggestions after full clear search input

### DIFF
--- a/src/components/DaData.vue
+++ b/src/components/DaData.vue
@@ -130,6 +130,7 @@ const search = () => {
     if (response && response.data) {
       if (typeof response.data.suggestions !== 'undefined') {
         suggestions.value = response.data.suggestions;
+        showList.value = suggestions.value.length;
       } else {
         console.error('vue-dadata-3:Свойство suggestions не найдено');
       }


### PR DESCRIPTION
Когда срабатывает фокус, открывается окно подсказок отображается
`showList.value = true;`

```php
const onFocus = () => {
  showList.value = true;
  if (localValue.value) {
    search();
  }
};
```

Но когда полностью очищаешь поле ввода - окно подсказок скрывается
`showList.value = false;`
Но в поиске `search()` если данные вновь приходят - подсказки уже не отображаются

```
watch(() => localValue.value, (val) => {
  emit('update:modelValue', val);
  if (val) {
    search();
  } else {
    showList.value = false;
    suggestions.value = [];
  }
});
```