### PR TITLE
Гранулярные подсказки

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,42 +139,67 @@ import "vue-dadata-3/index.css";
       type: Object as PropType<CssClasses>,
       default: () => ({}),
     },
+    locations: {
+      type: Object as PropType<LocationOptions>,
+      default: () => ({}),
+    },
+    fromBound: {
+      type: Object as PropType<DaDataBound>,
+      default: () => ({}),
+    },
+    toBound: {
+      type: Object as PropType<DaDataBound>,
+      default: () => ({}),
+    },
 }
 
 ```
 
-**token** - токен сервиса
+- **token** - токен сервиса
 
-**type** - тип [подсказок](https://dadata.ru/suggestions/usage/) по умолчанию address
+- **type** - тип [подсказок](https://dadata.ru/suggestions/usage/) по умолчанию address
 
-**mergeParams** - [параметры](https://confluence.hflabs.ru/display/SGTDOC/HTTP+API) запроса.
+- **mergeParams** - [параметры](https://confluence.hflabs.ru/display/SGTDOC/HTTP+API) запроса.
 
-**setInputValue** - коллбэк-функция, которая обрабатывает значение после выбора из подсказок. Принимает параметр объекта suggestion.
+- **setInputValue** - коллбэк-функция, которая обрабатывает значение после выбора из подсказок. Принимает параметр объекта suggestion.
 
-**apiUrl** - кастомный урл для отправки запросов, заменяет дефолтный.
+- **apiUrl** - кастомный урл для отправки запросов, заменяет дефолтный.
 
-**inputName** - значение атрибута name у input
+- **inputName** - значение атрибута name у input
 
-**inputId** - значение атрибута id у input
+- **inputId** - значение атрибута id у input
 
-**placeholder** - значение атрибута placeholder у input
+- **placeholder** - значение атрибута placeholder у input
 
-**debounceWait** - время задержки перед отправкой запроса
+- **debounceWait** - время задержки перед отправкой запроса
 
-**debounceOptions** - опции плагина [debounce](https://lodash.com/docs/4.17.15#debounce) пакета lodash
+- **debounceOptions** - опции плагина [debounce](https://lodash.com/docs/4.17.15#debounce) пакета lodash
 
-**cssClasses** - переопределение дефолтных css классов
+- **cssClasses** - переопределение дефолтных css классов
+  ```
+  type CssClasses = {
+    root: string,
+    input: string,
+    listEmpty: string,
+    row: string,
+    list: string
+  }
+  ```
+- **locations** - настройка ограничений и приоритетов для местности по которой осуществляется поиск. 
+Передаётся объектом со следующими опциональными полями:
 
-```
-type CssClasses = {
-  root: string,
-  input: string,
-  listEmpty: string,
-  row: string,
-  list: string
-}
+  | Название        | Тип                           | Описание                                                                                                            |
+  |-----------------|-------------------------------|---------------------------------------------------------------------------------------------------------------------|
+  | division        | "municipal"\|"administrative" | [Административное либо муниципальное деление](https://confluence.hflabs.ru/pages/viewpage.action?pageId=1326056589) |
+  | locations       | array[object]                 | [Ограничение сектора поиска](https://confluence.hflabs.ru/pages/viewpage.action?pageId=204669108)                   |
+  | locations_geo   | array[object]                 | [Ограничение по радиусу окружности](https://confluence.hflabs.ru/pages/viewpage.action?pageId=990871806)            |
+  | locations_boost | array[object]                 | [Приоритет города при ранжировании](https://confluence.hflabs.ru/pages/viewpage.action?pageId=285343795)            |
 
-```
+- **fromBound** и **toBound** - [гранулярные подсказки](https://confluence.hflabs.ru/pages/viewpage.action?pageId=222888017). Передаётся в виде объекта с полем value, содержащий нужный тип. Например, следующий элемент будет искать исключительно по городам: 
+
+  ```vue
+  <DaDataNext :from-bound="{value: 'city'}" :to-bound="{value: 'city'}"/>
+  ```
 
 ### События
 

--- a/src/components/useDaData.ts
+++ b/src/components/useDaData.ts
@@ -5,7 +5,6 @@ import {
   toRaw,
   onMounted,
   PropType,
-  ComponentPropsOptions,
 } from 'vue';
 import axios, { AxiosRequestConfig, AxiosResponse } from 'axios';
 import { merge, debounce as _debounce } from 'lodash-es';
@@ -17,7 +16,7 @@ import {
   DaDataSuggestionAnyType,
   DaDataSuggestions,
   ComposableDaData,
-  IPropsComponentContext,
+  Bounds,
 } from '../types';
 
 
@@ -35,7 +34,7 @@ export const CSS_CLASSES_DEFAULT: CssClasses = {
     row: 'dadata__list__row'
 }
 
-export const propsComponent: ComponentPropsOptions<IPropsComponentContext> = {
+export const propsComponent = {
     modelValue: {
         type: String,
         required: true

--- a/src/components/useDaData.ts
+++ b/src/components/useDaData.ts
@@ -17,6 +17,7 @@ import {
   DaDataSuggestions,
   ComposableDaData,
   LocationOptions,
+  DaDataAddressBounds,
 } from '../types';
 
 
@@ -86,6 +87,8 @@ export const propsComponent = {
       type: Object as PropType<LocationOptions>,
       default: () => ({}),
     },
+    fromBound: String as PropType<DaDataAddressBounds>,
+    toBound: String as PropType<DaDataAddressBounds>,
 }
 
 export const emitsComponent = ['update:modelValue', 'onSelected', 'focus', 'input'];
@@ -121,8 +124,6 @@ export const useDaData = (): ComposableDaData => {
     });
     const params = computed<AxiosRequestConfig>((): AxiosRequestConfig => {
         if (token.value) {
-            const {from_bound, to_bound, ...options} = props.restrictions;
-
             return merge({
                 method: 'POST',
                 url: url.value,
@@ -133,9 +134,9 @@ export const useDaData = (): ComposableDaData => {
                 },
                 data: {
                     query: localValue.value,
-                    ...options,
-                    ...(from_bound ? {from_bound: {value: from_bound}} : {}),
-                    ...(to_bound ? {to_bound: {value: to_bound}} : {}),
+                    ...props.restrictions,
+                    ...(props.fromBound ? {from_bound: {value: props.fromBound}} : {}),
+                    ...(props.toBound ? {to_bound: {value: props.toBound}} : {}),
                 },
             }, props.mergeParams);
         }

--- a/src/components/useDaData.ts
+++ b/src/components/useDaData.ts
@@ -83,7 +83,8 @@ export const propsComponent: ComponentPropsOptions<IPropsComponentContext> = {
       type: Object as PropType<CssClasses>,
       default: () => ({}),
     },
-    
+    fromBound: String as PropType<Bounds>,
+    toBound: String as PropType<Bounds>,
 }
 
 export const emitsComponent = ['update:modelValue', 'onSelected', 'focus', 'input'];
@@ -97,7 +98,7 @@ export const useDaData = (): ComposableDaData => {
     const token = computed(() => {
         if (props.token) return props.token;
         if(pluginSettings?.token) return pluginSettings.token;
-        return null;    
+        return null;
     });
     const localValue = computed({
         get(){
@@ -114,7 +115,7 @@ export const useDaData = (): ComposableDaData => {
         if (props.apiUrl) {
             return props.apiUrl;
         }
-        
+
         return `https://suggestions.dadata.ru/suggestions/api/4_1/rs/suggest/${props.type}`;
     });
     const params = computed<AxiosRequestConfig>((): AxiosRequestConfig => {
@@ -127,7 +128,11 @@ export const useDaData = (): ComposableDaData => {
                     'content-type': 'application/json',
                     accept: 'application/json',
                 },
-                data: { query: localValue.value },
+                data: {
+                    query: localValue.value,
+                    ...(props.fromBound ? {from_bound: {value: props.fromBound}} : {}),
+                    ...(props.toBound ? {to_bound: {value: props.toBound}} : {}),
+                },
             }, props.mergeParams);
         }
 
@@ -186,7 +191,7 @@ export const useDaData = (): ComposableDaData => {
 
         return copyValue;
     };
-   
+
 
     const search = _debounce((success = (data: any) => data, error = () => ({})): void => {
         if(!params.value){
@@ -210,7 +215,7 @@ export const useDaData = (): ComposableDaData => {
 
     const onSelected = (data: any): void => {
         localValue.value = data.value;
-        
+
         if ('setInputValue' in props && typeof props.setInputValue === 'function') {
             localValue.value = props.setInputValue(toRaw(data));
         }
@@ -227,7 +232,7 @@ export const useDaData = (): ComposableDaData => {
         }
         emit('focus', event);
     };
-    
+
     const onInput = (event: Event): void => {
         showList.value = true;
         const val = (event.target as HTMLInputElement).value;

--- a/src/components/useDaData.ts
+++ b/src/components/useDaData.ts
@@ -1,21 +1,23 @@
 import {
-    computed,
-    ref,
-    watch,
-    toRaw,
-    onMounted,
-    PropType,
-  } from 'vue';
+  computed,
+  ref,
+  watch,
+  toRaw,
+  onMounted,
+  PropType,
+  ComponentPropsOptions,
+} from 'vue';
 import axios, { AxiosRequestConfig, AxiosResponse } from 'axios';
 import { merge, debounce as _debounce } from 'lodash-es';
 import type { DebounceSettings } from "lodash-es";
 
 import { getCurrentInstance } from '../utils/getCurrentInstance';
-import { 
-    CssClasses,
-    DaDataSuggestionAnyType,
-    DaDataSuggestions,
-    ComposableDaData
+import {
+  CssClasses,
+  DaDataSuggestionAnyType,
+  DaDataSuggestions,
+  ComposableDaData,
+  IPropsComponentContext,
 } from '../types';
 
 
@@ -33,7 +35,7 @@ export const CSS_CLASSES_DEFAULT: CssClasses = {
     row: 'dadata__list__row'
 }
 
-export const propsComponent = {
+export const propsComponent: ComponentPropsOptions<IPropsComponentContext> = {
     modelValue: {
         type: String,
         required: true
@@ -47,7 +49,7 @@ export const propsComponent = {
       default: 'address',
     },
     setInputValue: {
-      type: Function,
+      type: Function as PropType<(item: DaDataSuggestionAnyType) => string>,
     },
     apiUrl: {
       type: String,

--- a/src/components/useDaData.ts
+++ b/src/components/useDaData.ts
@@ -13,11 +13,11 @@ import type { DebounceSettings } from "lodash-es";
 import { getCurrentInstance } from '../utils/getCurrentInstance';
 import {
   CssClasses,
+  DaDataBound,
   DaDataSuggestionAnyType,
   DaDataSuggestions,
   ComposableDaData,
   LocationOptions,
-  DaDataAddressBounds,
 } from '../types';
 
 
@@ -87,8 +87,14 @@ export const propsComponent = {
       type: Object as PropType<LocationOptions>,
       default: () => ({}),
     },
-    fromBound: String as PropType<DaDataAddressBounds>,
-    toBound: String as PropType<DaDataAddressBounds>,
+    fromBound: {
+      type: Object as PropType<DaDataBound>,
+      default: () => ({}),
+    },
+    toBound: {
+      type: Object as PropType<DaDataBound>,
+      default: () => ({}),
+    },
 }
 
 export const emitsComponent = ['update:modelValue', 'onSelected', 'focus', 'input'];
@@ -135,8 +141,8 @@ export const useDaData = (): ComposableDaData => {
                 data: {
                     query: localValue.value,
                     ...props.restrictions,
-                    ...(props.fromBound ? {from_bound: {value: props.fromBound}} : {}),
-                    ...(props.toBound ? {to_bound: {value: props.toBound}} : {}),
+                    ...props.fromBound,
+                    ...props.toBound,
                 },
             }, props.mergeParams);
         }

--- a/src/components/useDaData.ts
+++ b/src/components/useDaData.ts
@@ -83,7 +83,7 @@ export const propsComponent = {
       type: Object as PropType<CssClasses>,
       default: () => ({}),
     },
-    restrictions: {
+    locations: {
       type: Object as PropType<LocationOptions>,
       default: () => ({}),
     },
@@ -140,7 +140,7 @@ export const useDaData = (): ComposableDaData => {
                 },
                 data: {
                     query: localValue.value,
-                    ...props.restrictions,
+                    ...props.locations,
                     ...props.fromBound,
                     ...props.toBound,
                 },

--- a/src/components/useDaData.ts
+++ b/src/components/useDaData.ts
@@ -16,7 +16,7 @@ import {
   DaDataSuggestionAnyType,
   DaDataSuggestions,
   ComposableDaData,
-  Bounds,
+  LocationOptions,
 } from '../types';
 
 
@@ -82,8 +82,10 @@ export const propsComponent = {
       type: Object as PropType<CssClasses>,
       default: () => ({}),
     },
-    fromBound: String as PropType<Bounds>,
-    toBound: String as PropType<Bounds>,
+    restrictions: {
+      type: Object as PropType<LocationOptions>,
+      default: () => ({}),
+    },
 }
 
 export const emitsComponent = ['update:modelValue', 'onSelected', 'focus', 'input'];
@@ -119,6 +121,8 @@ export const useDaData = (): ComposableDaData => {
     });
     const params = computed<AxiosRequestConfig>((): AxiosRequestConfig => {
         if (token.value) {
+            const {from_bound, to_bound, ...options} = props.restrictions;
+
             return merge({
                 method: 'POST',
                 url: url.value,
@@ -129,8 +133,9 @@ export const useDaData = (): ComposableDaData => {
                 },
                 data: {
                     query: localValue.value,
-                    ...(props.fromBound ? {from_bound: {value: props.fromBound}} : {}),
-                    ...(props.toBound ? {to_bound: {value: props.toBound}} : {}),
+                    ...options,
+                    ...(from_bound ? {from_bound: {value: from_bound}} : {}),
+                    ...(to_bound ? {to_bound: {value: to_bound}} : {}),
                 },
             }, props.mergeParams);
         }

--- a/src/types.ts
+++ b/src/types.ts
@@ -221,6 +221,7 @@ export interface IPropsComponentContext {
   setInputValue?: (item: DaDataSuggestionAnyType) => string,
   apiUrl: string,
   inputName: string,
+  inputId: string,
   placeholder: string,
   mergeParams: Record<string, any>,
   debounceWait: number,

--- a/src/types.ts
+++ b/src/types.ts
@@ -271,7 +271,7 @@ export interface IPropsComponentContext {
   debounceWait: number,
   debounceOptions: DebounceSettings,
   cssClasses: CssClasses | Record<string, string>,
-  restrictions: LocationOptions,
+  locations: LocationOptions,
   fromBound: DaDataBound,
   toBound: DaDataBound,
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -99,7 +99,7 @@ export type DaDataAddress = {
   metro: DaDataAddressMetro[] | null;
 }
 
-export type DaDataAddressBounds = 'country' | 'region' | 'area' | 'city' | 'settlement' | 'street' | 'houses';
+export type DaDataAddressBounds = 'country' | 'region' | 'area' | 'city' | 'settlement' | 'street' | 'houses' | 'flat';
 
 export type DaDataPartyType = 'LEGAL' | 'INDIVIDUAL';
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -191,13 +191,13 @@ export type DaDataFio = {
 }
 
 export type DaDataSuggestionAnyType =
-   DaDataResult<DaDataAddress>  | 
-   DaDataResult<DaDataBank>     |  
+   DaDataResult<DaDataAddress>  |
+   DaDataResult<DaDataBank>     |
    DaDataResult<DaDataParty>    |
    DaDataResult<DaDataFio>;
 
 export type DaDataSuggestions = {
-  suggestions: DaDataSuggestionAnyType[] 
+  suggestions: DaDataSuggestionAnyType[]
 }
 
 
@@ -227,6 +227,8 @@ export interface IPropsComponentContext {
   debounceWait: number,
   debounceOptions: DebounceSettings,
   cssClasses: CssClasses | Record<string, string>,
+  fromBound: Bounds,
+  toBound: Bounds,
 }
 
 export type CurrentInstance = {
@@ -247,6 +249,8 @@ export type ComposableDaData = {
   dadataDom: Ref<HTMLElement | null>,
   suggestions: Ref<DaDataSuggestionAnyType[]>
 }
+
+export type Bounds = 'country' | 'region' | 'area' | 'city' | 'settlement' | 'street' | 'house' | 'flat';
 
 declare module '@vue/runtime-core' {
   export interface ComponentCustomProperties {

--- a/src/types.ts
+++ b/src/types.ts
@@ -246,6 +246,9 @@ export interface DaDataLocationGeoRestriction {
 export interface DaDataLocationBoostRestriction {
   kladr_id: string | number,
 }
+
+export interface DaDataBound {
+  value: DaDataAddressBounds;
 }
 
 export interface LocationOptions {
@@ -269,8 +272,8 @@ export interface IPropsComponentContext {
   debounceOptions: DebounceSettings,
   cssClasses: CssClasses | Record<string, string>,
   restrictions: LocationOptions,
-  fromBound: DaDataAddressBounds,
-  toBound: DaDataAddressBounds,
+  fromBound: DaDataBound,
+  toBound: DaDataBound,
 }
 
 export type CurrentInstance = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -214,6 +214,48 @@ export type CssClasses = {
   list: string
 }
 
+export type Divisions = 'administrative' | 'municipal';
+
+export interface LocationRestriction {
+  country_iso_code?: string;
+  region_iso_code?: string;
+
+  kladr_id?: string|number;
+  fias_id?: string;
+
+  country?: string;
+  region?: string;
+  area?: string;
+  city?: string;
+  settlement?: string;
+  street?: string;
+
+  region_type_full?: string;
+  area_type_full?: string;
+  city_type_full?: string;
+  settlement_type_full?: string;
+  street_type_full?: string;
+}
+
+interface LocationGeoRestriction {
+  lat: number;
+  lon: number;
+  radius_meters?: number;
+}
+
+interface LocationBoostRestriction {
+  kladr_id: string|number,
+}
+
+export interface LocationOptions {
+  division?: Divisions,
+  locations?: Array<LocationRestriction>,
+  locations_geo?: Array<LocationGeoRestriction>,
+  locations_boost?: Array<LocationBoostRestriction>,
+  from_bound: DaDataAddressBounds,
+  to_bound: DaDataAddressBounds,
+}
+
 export interface IPropsComponentContext {
   modelValue: string,
   token: string,
@@ -227,8 +269,7 @@ export interface IPropsComponentContext {
   debounceWait: number,
   debounceOptions: DebounceSettings,
   cssClasses: CssClasses | Record<string, string>,
-  fromBound: Bounds,
-  toBound: Bounds,
+  restrictions: LocationOptions,
 }
 
 export type CurrentInstance = {
@@ -249,8 +290,6 @@ export type ComposableDaData = {
   dadataDom: Ref<HTMLElement | null>,
   suggestions: Ref<DaDataSuggestionAnyType[]>
 }
-
-export type Bounds = 'country' | 'region' | 'area' | 'city' | 'settlement' | 'street' | 'house' | 'flat';
 
 declare module '@vue/runtime-core' {
   export interface ComponentCustomProperties {

--- a/src/types.ts
+++ b/src/types.ts
@@ -214,46 +214,46 @@ export type CssClasses = {
   list: string
 }
 
-export type Divisions = 'administrative' | 'municipal';
+namespace DaData {
+  export type Divisions = 'administrative' | 'municipal';
 
-export interface LocationRestriction {
-  country_iso_code?: string;
-  region_iso_code?: string;
+  export interface LocationRestriction {
+    country_iso_code?: string;
+    region_iso_code?: string;
 
-  kladr_id?: string|number;
-  fias_id?: string;
+    kladr_id?: string|number;
+    fias_id?: string;
 
-  country?: string;
-  region?: string;
-  area?: string;
-  city?: string;
-  settlement?: string;
-  street?: string;
+    country?: string;
+    region?: string;
+    area?: string;
+    city?: string;
+    settlement?: string;
+    street?: string;
 
-  region_type_full?: string;
-  area_type_full?: string;
-  city_type_full?: string;
-  settlement_type_full?: string;
-  street_type_full?: string;
-}
+    region_type_full?: string;
+    area_type_full?: string;
+    city_type_full?: string;
+    settlement_type_full?: string;
+    street_type_full?: string;
+  }
 
-interface LocationGeoRestriction {
-  lat: number;
-  lon: number;
-  radius_meters?: number;
-}
+  export interface LocationGeoRestriction {
+    lat: number;
+    lon: number;
+    radius_meters?: number;
+  }
 
-interface LocationBoostRestriction {
-  kladr_id: string|number,
+  export interface LocationBoostRestriction {
+    kladr_id: string|number,
+  }
 }
 
 export interface LocationOptions {
-  division?: Divisions,
-  locations?: Array<LocationRestriction>,
-  locations_geo?: Array<LocationGeoRestriction>,
-  locations_boost?: Array<LocationBoostRestriction>,
-  from_bound: DaDataAddressBounds,
-  to_bound: DaDataAddressBounds,
+  division?: DaData.Divisions,
+  locations?: Array<DaData.LocationRestriction>,
+  locations_geo?: Array<DaData.LocationGeoRestriction>,
+  locations_boost?: Array<DaData.LocationBoostRestriction>,
 }
 
 export interface IPropsComponentContext {
@@ -270,6 +270,8 @@ export interface IPropsComponentContext {
   debounceOptions: DebounceSettings,
   cssClasses: CssClasses | Record<string, string>,
   restrictions: LocationOptions,
+  fromBound: DaDataAddressBounds,
+  toBound: DaDataAddressBounds,
 }
 
 export type CurrentInstance = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
-import { DebounceSettings } from "lodash-es";
-import { Ref, WritableComputedRef, ComputedRef} from 'vue';
+import {DebounceSettings} from "lodash-es";
+import {Ref, WritableComputedRef, ComputedRef} from 'vue';
 
 
 
@@ -214,46 +214,45 @@ export type CssClasses = {
   list: string
 }
 
-namespace DaData {
-  export type Divisions = 'administrative' | 'municipal';
+export type DaDataDivisions = 'administrative' | 'municipal';
 
-  export interface LocationRestriction {
-    country_iso_code?: string;
-    region_iso_code?: string;
+export interface DaDataLocationRestriction {
+  country_iso_code?: string;
+  region_iso_code?: string;
 
-    kladr_id?: string|number;
-    fias_id?: string;
+  kladr_id?: string | number;
+  fias_id?: string;
 
-    country?: string;
-    region?: string;
-    area?: string;
-    city?: string;
-    settlement?: string;
-    street?: string;
+  country?: string;
+  region?: string;
+  area?: string;
+  city?: string;
+  settlement?: string;
+  street?: string;
 
-    region_type_full?: string;
-    area_type_full?: string;
-    city_type_full?: string;
-    settlement_type_full?: string;
-    street_type_full?: string;
-  }
+  region_type_full?: string;
+  area_type_full?: string;
+  city_type_full?: string;
+  settlement_type_full?: string;
+  street_type_full?: string;
+}
 
-  export interface LocationGeoRestriction {
-    lat: number;
-    lon: number;
-    radius_meters?: number;
-  }
+export interface DaDataLocationGeoRestriction {
+  lat: number;
+  lon: number;
+  radius_meters?: number;
+}
 
-  export interface LocationBoostRestriction {
-    kladr_id: string|number,
-  }
+export interface DaDataLocationBoostRestriction {
+  kladr_id: string | number,
+}
 }
 
 export interface LocationOptions {
-  division?: DaData.Divisions,
-  locations?: Array<DaData.LocationRestriction>,
-  locations_geo?: Array<DaData.LocationGeoRestriction>,
-  locations_boost?: Array<DaData.LocationBoostRestriction>,
+  division?: DaDataDivisions,
+  locations?: Array<DaDataLocationRestriction>,
+  locations_geo?: Array<DaDataLocationGeoRestriction>,
+  locations_boost?: Array<DaDataLocationBoostRestriction>,
 }
 
 export interface IPropsComponentContext {


### PR DESCRIPTION
dadata поддерживает [гранулярные подсказки](https://confluence.hflabs.ru/pages/viewpage.action?pageId=222888017), то есть, можно указать какого именно типа географические данные мы хотим получить. С помощью этих параметров (from_bound/to_bound) можно ограничить область подсказок только городами и получить поле, в котором можно указать только город, а не весь адрес. Этот мердж содержит данный функционал - в параметры компонента добавлены поля `fromBound`/`toBound` и они соответственно добавляются в тело запроса.

Также, местами наблюдаются конфликты по форматированию - с одной стороны, присутствует `.editorconfig` с описанными там правилами форматирования, а с другой - сами файлы отформатированы в 4 пробелами (вместо двух) для таба и регулярно встречаются строки с висячими пробелами. Что делать с подобными вещами? Переформатировать приводя к общему виду по мере правки или как? В данном мердже постарался свести к минимуму правки по форматированию, но совсем без них не обошлось