### PR TITLE
Исправление сборки параметров API

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,10 +195,10 @@ import "vue-dadata-3/index.css";
   | locations_geo   | array[object]                 | [Ограничение по радиусу окружности](https://confluence.hflabs.ru/pages/viewpage.action?pageId=990871806)            |
   | locations_boost | array[object]                 | [Приоритет города при ранжировании](https://confluence.hflabs.ru/pages/viewpage.action?pageId=285343795)            |
 
-- **fromBound** и **toBound** - [гранулярные подсказки](https://confluence.hflabs.ru/pages/viewpage.action?pageId=222888017). Передаётся в виде объекта с полем value, содержащий нужный тип. Например, следующий элемент будет искать исключительно по городам: 
+- **fromBound** и **toBound** - [гранулярные подсказки](https://confluence.hflabs.ru/pages/viewpage.action?pageId=222888017). Передаётся в строки, содержащий нужный тип. Например, следующий элемент будет искать исключительно по городам: 
 
   ```vue
-  <DaDataNext :from-bound="{value: 'city'}" :to-bound="{value: 'city'}"/>
+  <DaDataNext from-bound="city" to-bound="city"/>
   ```
 
 ### События
@@ -219,7 +219,3 @@ import "vue-dadata-3/index.css";
 
 Функция **prepareValue** нужна для сохранения подсветки соответствий запроса. 
 Эта функция опциональна. Если все-таки решили её использовать, то нужно выводить, как в примере выше через директиву v-html.
-
-
-
-

--- a/src/components/useDaData.ts
+++ b/src/components/useDaData.ts
@@ -14,6 +14,7 @@ import { getCurrentInstance } from '../utils/getCurrentInstance';
 import {
   CssClasses,
   DaDataBound,
+  DaDataQueryData,
   DaDataSuggestionAnyType,
   DaDataSuggestions,
   ComposableDaData,
@@ -128,7 +129,7 @@ export const useDaData = (): ComposableDaData => {
 
         return `https://suggestions.dadata.ru/suggestions/api/4_1/rs/suggest/${props.type}`;
     });
-    const params = computed<AxiosRequestConfig>((): AxiosRequestConfig => {
+    const params = computed<AxiosRequestConfig<DaDataQueryData>>((): AxiosRequestConfig<DaDataQueryData> => {
         if (token.value) {
             return merge({
                 method: 'POST',

--- a/src/components/useDaData.ts
+++ b/src/components/useDaData.ts
@@ -13,7 +13,7 @@ import type { DebounceSettings } from "lodash-es";
 import { getCurrentInstance } from '../utils/getCurrentInstance';
 import {
   CssClasses,
-  DaDataBound,
+  DaDataAddressBounds,
   DaDataQueryData,
   DaDataSuggestionAnyType,
   DaDataSuggestions,
@@ -89,11 +89,11 @@ export const propsComponent = {
       default: () => ({}),
     },
     fromBound: {
-      type: Object as PropType<DaDataBound>,
+      type: String as PropType<DaDataAddressBounds>,
       default: () => ({}),
     },
     toBound: {
-      type: Object as PropType<DaDataBound>,
+      type: String as PropType<DaDataAddressBounds>,
       default: () => ({}),
     },
 }
@@ -139,17 +139,33 @@ export const useDaData = (): ComposableDaData => {
                     'content-type': 'application/json',
                     accept: 'application/json',
                 },
-                data: {
-                    query: localValue.value,
-                    ...props.locations,
-                    ...props.fromBound,
-                    ...props.toBound,
-                },
+                data: buildQueryData(),
             }, props.mergeParams);
         }
 
         return {};
     });
+
+    const buildQueryData = (): DaDataQueryData => {
+        const data: DaDataQueryData = {
+            query: localValue.value,
+            ...props.locations,
+        };
+
+        if (props.fromBound) {
+            data['from_bound'] = {
+                value: props.fromBound,
+            };
+        }
+
+        if (props.toBound) {
+            data['to_bound'] = {
+                value: props.toBound,
+            };
+        }
+
+        return data;
+    }
 
     const bindCloseClickOutside = () => {
         document.addEventListener('click', (event: Event) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -200,6 +200,14 @@ export type DaDataSuggestions = {
   suggestions: DaDataSuggestionAnyType[]
 }
 
+// Документация: https://confluence.hflabs.ru/pages/viewpage.action?pageId=204669107#id-%D0%9F%D0%BE%D0%B4%D1%81%D0%BA%D0%B0%D0%B7%D0%BA%D0%B8%D0%BF%D0%BE%D0%B0%D0%B4%D1%80%D0%B5%D1%81%D1%83(API)-%D0%9F%D0%B0%D1%80%D0%B0%D0%BC%D0%B5%D1%82%D1%80%D1%8B
+export interface DaDataQueryData extends LocationOptions {
+  query: string,
+  count?: number,
+  language?: string,
+  from_bound?: DaDataBound,
+  to_bound?: DaDataBound,
+}
 
 export interface PluginOptions {
   tag?: string,

--- a/src/types.ts
+++ b/src/types.ts
@@ -280,8 +280,8 @@ export interface IPropsComponentContext {
   debounceOptions: DebounceSettings,
   cssClasses: CssClasses | Record<string, string>,
   locations: LocationOptions,
-  fromBound: DaDataBound,
-  toBound: DaDataBound,
+  fromBound: DaDataAddressBounds,
+  toBound: DaDataAddressBounds,
 }
 
 export type CurrentInstance = {


### PR DESCRIPTION
Оказалось, что по факту запрос к API собирался не таким какой должен быть, вместо такого:

```json
{
  "query": "city",
  "from_bound": {
    "value": "city",
  }
}
```

Получалось такое:

```json
{
  "query": "city",
  "value": "city",
}
```

Для исправления было сделано следующее:

1. Добавлена [типизация для запроса](https://github.com/Stanislavsky69/vue_dadata_3/pull/20/files#diff-23dfc3b95851348dd0ddf21c367f60d3587bb8469df6fba7521f25d45e4b0ed9L131-R132) (он не был типизирован), на основании описания объекта в [документации](https://confluence.hflabs.ru/pages/viewpage.action?pageId=204669107#id-%D0%9F%D0%BE%D0%B4%D1%81%D0%BA%D0%B0%D0%B7%D0%BA%D0%B8%D0%BF%D0%BE%D0%B0%D0%B4%D1%80%D0%B5%D1%81%D1%83(API)-%D0%9F%D0%B0%D1%80%D0%B0%D0%BC%D0%B5%D1%82%D1%80%D1%8B).
2. Постройка тела запроса вынесена в [отдельнй метод](https://github.com/TiGR/vue_dadata_3/blob/feature/fix-bounds-api-request/src/components/useDaData.ts#L149-L168) для лучшей читаемости кода
3. Поскольку [теперь ручками создаются поля bound](https://github.com/TiGR/vue_dadata_3/blob/feature/fix-bounds-api-request/src/components/useDaData.ts#L155-L165), то смысла выносить наружу объект с value больше нет. Поэтому пропсы упрощены до строкового значения. Кстати, этот код [практически такой же как и в jquery-suggestions](https://github.com/hflabs/suggestions-jquery/blob/master/src/includes/bounds.js#L71-L83).