### PR TITLE
Исправлен ошибочный запрос через axios в случае пустого запроса

### DIFF
--- a/src/components/useDaData.ts
+++ b/src/components/useDaData.ts
@@ -131,8 +131,8 @@ export const useDaData = (): ComposableDaData => {
     });
 
     function makeRequestParams(url: string, token: string|null, query: string, data: Partial<DaDataQueryData> = {}, params: Record<string, any> = {}): AxiosRequestConfig<DaDataQueryData> {
-      if (!token || !query.trim()) {
-        return {};
+      if (!token) {
+        throw new Error('No DaData token provided');
       }
 
       return merge({
@@ -222,6 +222,10 @@ export const useDaData = (): ComposableDaData => {
     };
 
     function apiRequest(query: string, data: Partial<DaDataQueryData> = {}): Promise<DaDataSuggestionAnyType[]|undefined> {
+      if (!query.trim()) {
+        return new Promise(resolve => resolve());
+      }
+
       const params = makeRequestParams(url.value, token.value, query, data, props.mergeParams);
 
       return axios(params)


### PR DESCRIPTION
В случае если запрос является пустым, makeRequestParams возвращал пустой объект параметров axios. После этого происходил вызов axios, который вызывал ошибку. Для исправления сделано следующее:

1. Проверка на пустой запрос вынесена из makeRequestParams в apiRequest и в случае если строка пустая, то возвращается промис с пустым результатом (это корректно обрабатывается в коде)
2. Также в случае если не указан токен для API, добавлен эксепшн с чётким описанием ошибки