### PR TITLE
Fix ts(7016)

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "module": "./dist/index.es.js",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.es.js",
       "require": "./dist/index.umd.js"
     },


### PR DESCRIPTION
This PR fixes the ts error:
Could not find a declaration file for module 'vue-dadata-3'. implicitly has an 'any' type. There are types at * but this result could not be resolved when respecting package.json "exports". The 'vue-dadata-3' library may need to update its package.json or typings. ts(7016)